### PR TITLE
SSO scaling SOP update

### DIFF
--- a/sops/3scale-scaling.md
+++ b/sops/3scale-scaling.md
@@ -23,7 +23,7 @@ oc scale dc backend-listener -n <ns-prefix>-3scale --replicas=<number-of-replica
 #### Scalability:
 - Pod **anti-affinity** rule is important here
 - Critical functionality -- rate limits depend on this component
-- Depending on the number of reports you should check the lenght of the redis queues for jobs
+- Depending on the number of reports you should check the length of the redis queues for jobs
 - Can be scaled **horizontally** by adding more PODs as needed.
 ```
 oc scale dc backend-worker -n <ns-prefix>-3scale --replicas=<number-of-replicas>

--- a/sops/sso-scaling.md
+++ b/sops/sso-scaling.md
@@ -9,7 +9,10 @@ The purpose of this guide is to outline the existing scaling capabilities of SSO
 - Response time is expensive due to password hashing
 - User sessions are kept in memory
 - Heavy reliance on caching 
-- Manual Scaling is possible : 
+
+#### Scalability
+- The default deployment of 1 pod allows a maximum rate of 7 users to login/logout per second. Scaling to 2 pods increases this number to 14 users per second. Adding further pods gives a minimal performance increase
+- This component scales **horizontally** by adding more pods:
 ```
 oc scale dc sso -n <ns-prefix>-sso --replicas=<number-of-replicas>
 ```
@@ -18,4 +21,5 @@ oc scale dc sso -n <ns-prefix>-sso --replicas=<number-of-replicas>
 - There is no auto-scaling support
 - There are no metrics provided for scaling
 - User sessions are kept in memory
-- Heavy reliance on caching 
+- Heavy reliance on caching
+- No performance issues were encountered during load testing


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-3416

The scaling guide contains instructions on how to scale the RH-SSO server. These instructions are based on the results of the RH-SSO load testing that was completed as part of [INTLY-2652](https://issues.jboss.org/browse/INTLY-2652), the results of which can be found [HERE](https://docs.google.com/spreadsheets/d/1VGL87kaSKaz7ndjj1tNlRQiYDf2zn-lT1uHeOCPII3M/edit#gid=1464736922).

The load testing results showed that scaling from the default deployment of 1 SSO pod to 2 pods gave the largest increase in performance. Adding additional pods and/or tweaking the various other parameters added little in terms of performance benefits.

## Verification Steps
1. Review the SSO load testing results, and ensure that the scaling instructions align with the results of the testing