### PR TITLE
INTLY-7163 Update steps for manual setup

### DIFF
--- a/amq-online/README.md
+++ b/amq-online/README.md
@@ -34,10 +34,8 @@ Test results can be found at `reports-your-subdomain.com`
 ### Creating addresses
 To meet the description use cases outlined above a number of addresses need to be created.
 
-First, we need remove the standard authservice and to create a none authentication service.
-```
-oc project redhat-rhmi-amq-online
-```
+Login to the cluster using ` oc login ` command
+
 Now we will create our address spaces and addresses in a different project
 ```
 oc new-project maestro-test-addresses

--- a/amq-online/README.md
+++ b/amq-online/README.md
@@ -36,9 +36,7 @@ To meet the description use cases outlined above a number of addresses need to b
 
 First, we need remove the standard authservice and to create a none authentication service.
 ```
-oc project openshift-enmasse
-oc delete authenticationservice standard-authservice
-oc create -f enmasse/authservice/none-authservice.yaml
+oc project redhat-rhmi-amq-online
 ```
 Now we will create our address spaces and addresses in a different project
 ```
@@ -155,7 +153,7 @@ Each test case is run by creating a configmap with the parameters for the test, 
 
 To run a test first you must update `testcase-1.yaml` to match your Receive Url
 ```
-oc apply -f maestro/oc/client/testcase-1.yaml
+oc apply -f maestro/oc/client/testcases/testcase-1.yaml
 oc apply -f maestro/oc/client/client.yaml
 ```
 The test is finished once the job is marked as complete. If the test fails it will be rerun. You can view the progress in the client pod's logs. 

--- a/amq-online/enmasse/address/integreatly_brokered.yaml
+++ b/amq-online/enmasse/address/integreatly_brokered.yaml
@@ -1,4 +1,4 @@
-apiVersion: enmasse.io/v1alpha1
+apiVersion: enmasse.io/v1beta1
 kind: AddressList
 items:
   - metadata:

--- a/amq-online/enmasse/address/integreatly_standard.yaml
+++ b/amq-online/enmasse/address/integreatly_standard.yaml
@@ -1,4 +1,4 @@
-apiVersion: enmasse.io/v1alpha1
+apiVersion: enmasse.io/v1beta1
 kind: AddressList
 items:
   - metadata:

--- a/amq-online/enmasse/addressspace/brokered.yaml
+++ b/amq-online/enmasse/addressspace/brokered.yaml
@@ -1,4 +1,4 @@
-apiVersion: enmasse.io/v1alpha1
+apiVersion: enmasse.io/v1beta1
 kind: AddressSpace
 metadata:
   name: brokered
@@ -6,4 +6,4 @@ spec:
   type: brokered
   plan: brokered-single-broker
   autenticationService:
-    type: none
+    name: none-authservice

--- a/amq-online/enmasse/addressspace/standard.yaml
+++ b/amq-online/enmasse/addressspace/standard.yaml
@@ -6,5 +6,5 @@ spec:
   type: standard
   plan: standard-unlimited 
   autenticationService:
-    type: none-authservice
+    name: none-authservice
 

--- a/amq-online/enmasse/addressspace/standard.yaml
+++ b/amq-online/enmasse/addressspace/standard.yaml
@@ -6,5 +6,5 @@ spec:
   type: standard
   plan: standard-unlimited 
   autenticationService:
-    type: none
+    type: none-authservice
 


### PR DESCRIPTION
**What**
Updated the manual setup steps in  Readme and other files usefull for manually running this test on rhmi 2.x cluster.

**To Verify**
Follow the manual steps here
https://github.com/STEPHINRACHEL/middleware-load-testing/tree/INTLY-7163/amq-online#manual-setup-and-execution